### PR TITLE
Fix ellipsis character in retry log

### DIFF
--- a/Test3.py
+++ b/Test3.py
@@ -220,7 +220,7 @@ def main():
             except Exception:
                 attempts += 1
                 if attempts < MAX_RETRIES:
-                    logging.info("Retrying %s in %d seconds…", url, RETRY_DELAY)
+                    logging.info("Retrying %s in %d seconds...", url, RETRY_DELAY)
                     time.sleep(RETRY_DELAY)
                 else:
                     logging.error("Skipping %s after %d failures.", url, attempts)


### PR DESCRIPTION
## Summary
- replace Unicode ellipsis with standard periods in the retry log message

## Testing
- `python3 -m py_compile Test3.py`

------
https://chatgpt.com/codex/tasks/task_e_68715f4da7ec832e9dacccb93d5a53bf